### PR TITLE
Add T3D export option for map packages

### DIFF
--- a/UE Explorer/ExportHelpers.cs
+++ b/UE Explorer/ExportHelpers.cs
@@ -82,5 +82,32 @@ namespace UEExplorer
             package.CreateUPKGFile( exportPath );
             return exportPath;
         }
+
+        public static string ExportMapT3D( this UnrealPackage package )
+        {
+            Program.LoadConfig();
+            string exportPath = package.InitializeExportDirectory();
+
+            try
+            {
+                var level = package.Objects.OfType<ULevel>().FirstOrDefault( l => l.ExportTable != null );
+                if( level != null )
+                {
+                    var t3dContent = level.ExportToT3D();
+                    File.WriteAllText(
+                        Path.Combine( exportPath, package.PackageName + ".t3d" ),
+                        t3dContent,
+                        UnrealEncoding.ANSI
+                    );
+                }
+            }
+            catch( Exception e )
+            {
+                Console.WriteLine( "Couldn't export map to T3D\r\n" + e );
+            }
+
+            package.CreateUPKGFile( exportPath );
+            return exportPath;
+        }
     }
 }

--- a/UE Explorer/ExportHelpers.cs
+++ b/UE Explorer/ExportHelpers.cs
@@ -94,10 +94,17 @@ namespace UEExplorer
                 var level = package.Objects.OfType<ULevel>().FirstOrDefault( l => l.ExportTable != null );
                 if( level != null )
                 {
-                    var t3dContent = level.ExportToT3D();
+                    var t3dBuilder = new StringBuilder();
+                    t3dBuilder.Append( level.ExportToT3D() );
+                    if( level.Model != null )
+                    {
+                        t3dBuilder.AppendLine();
+                        t3dBuilder.Append( level.Model.ExportToT3D() );
+                    }
+
                     File.WriteAllText(
                         Path.Combine( rootPath, package.PackageName + ".t3d" ),
-                        t3dContent,
+                        t3dBuilder.ToString(),
                         UnrealEncoding.ANSI
                     );
                 }

--- a/UE Explorer/ExportHelpers.cs
+++ b/UE Explorer/ExportHelpers.cs
@@ -24,8 +24,8 @@ namespace UEExplorer
                 var files = Directory.GetFiles( exportPath );
                 foreach( var file in files )
                 {
-                    File.Delete( exportPath + file );
-                }			
+                    File.Delete( file );
+                }
             }
             var classPath = Path.Combine( exportPath, ClassesDir );
             Directory.CreateDirectory( classPath );
@@ -86,7 +86,8 @@ namespace UEExplorer
         public static string ExportMapT3D( this UnrealPackage package )
         {
             Program.LoadConfig();
-            string exportPath = package.InitializeExportDirectory();
+            string classPath = package.InitializeExportDirectory();
+            var rootPath = Path.GetDirectoryName( classPath );
 
             try
             {
@@ -95,7 +96,7 @@ namespace UEExplorer
                 {
                     var t3dContent = level.ExportToT3D();
                     File.WriteAllText(
-                        Path.Combine( exportPath, package.PackageName + ".t3d" ),
+                        Path.Combine( rootPath, package.PackageName + ".t3d" ),
                         t3dContent,
                         UnrealEncoding.ANSI
                     );
@@ -106,8 +107,8 @@ namespace UEExplorer
                 Console.WriteLine( "Couldn't export map to T3D\r\n" + e );
             }
 
-            package.CreateUPKGFile( exportPath );
-            return exportPath;
+            package.CreateUPKGFile( rootPath );
+            return rootPath;
         }
     }
 }

--- a/UE Explorer/Properties/Resources.Designer.cs
+++ b/UE Explorer/Properties/Resources.Designer.cs
@@ -219,6 +219,17 @@ namespace UEExplorer.Properties {
                 return ResourceManager.GetString("EXPORTED_ALL_PACKAGE_CLASSES", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Exported map of {0} to {1}
+        ///
+        ///Click Yes if you want to go to the output directory!.
+        /// </summary>
+        internal static string EXPORTED_MAP_T3D {
+            get {
+                return ResourceManager.GetString("EXPORTED_MAP_T3D", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Exporting package {0}.

--- a/UE Explorer/Properties/Resources.nl.resx
+++ b/UE Explorer/Properties/Resources.nl.resx
@@ -213,6 +213,11 @@ Laatste versie: {1}</value>
 
 Klik op ja als je nu naar deze map wilt gebracht worden!</value>
   </data>
+  <data name="EXPORTED_MAP_T3D" xml:space="preserve">
+    <value>Map van {0} is naar {1} geëxporteerd.
+
+Klik op ja als je naar deze map wilt gaan!</value>
+  </data>
   <data name="PACKAGE_IS_COMPRESSED" xml:space="preserve">
     <value>Dit pakket is gecompresseerd! Deze pakketen zijn niet ondersteund.
 Om dit te decompresseren moet je "Unreal Package Decompressor" van Gildor downloaden.

--- a/UE Explorer/Properties/Resources.resx
+++ b/UE Explorer/Properties/Resources.resx
@@ -198,6 +198,11 @@ If you happen to move the "UE Explorer" folder, uninstall or update it, then ple
 
 Click Yes if you want to go to the output directory!</value>
   </data>
+  <data name="EXPORTED_MAP_T3D" xml:space="preserve">
+    <value>Exported map of {0} to {1}
+
+Click Yes if you want to go to the output directory!</value>
+  </data>
   <data name="HexView_COULDNT_ACQUIRE_VALUE" xml:space="preserve">
     <value>Couldn't acquire value</value>
   </data>

--- a/UE Explorer/UI/Main/ProgramConsole.cs
+++ b/UE Explorer/UI/Main/ProgramConsole.cs
@@ -63,8 +63,9 @@ namespace UEExplorer.UI.Main
                         break;
 
                     case "export":
-                    { 
+                    {
                         bool shouldExportScripts = false;
+                        bool exportT3D = false;
                         switch( secondary )
                         {
                             case "classes":
@@ -72,6 +73,10 @@ namespace UEExplorer.UI.Main
 
                             case "scripts":
                                 shouldExportScripts = true;
+                                break;
+
+                            case "t3d":
+                                exportT3D = true;
                                 break;
 
                             default:
@@ -83,8 +88,10 @@ namespace UEExplorer.UI.Main
                         {
                             Console.WriteLine( Resources.EXPORTING_PACKAGE, filePath );
                             using( var package = UnrealLoader.LoadFullPackage( filePath ) )
-                            { 
-                                var exportPath = package.ExportPackageClasses( shouldExportScripts );
+                            {
+                                var exportPath = exportT3D
+                                    ? package.ExportMapT3D()
+                                    : package.ExportPackageClasses( shouldExportScripts );
                                 Console.WriteLine( Resources.PACKAGE_EXPORTED_TO, exportPath );
                             }
                         }

--- a/UE Explorer/UI/Main/ProgramForm.Designer.cs
+++ b/UE Explorer/UI/Main/ProgramForm.Designer.cs
@@ -48,6 +48,7 @@ namespace UEExplorer.UI
             this.menuItem22 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuItem13 = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportMapT3DMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.separator3 = new System.Windows.Forms.ToolStripSeparator();
             this.cacheExtractorMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.separator4 = new System.Windows.Forms.ToolStripSeparator();
@@ -268,6 +269,7 @@ namespace UEExplorer.UI
             // 
             this.toolsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuItem13,
+            this.exportMapT3DMenuItem,
             this.separator3,
             this.cacheExtractorMenuItem,
             this.separator4,
@@ -277,14 +279,20 @@ namespace UEExplorer.UI
             this.toolsMenuItem.Name = "toolsMenuItem";
             resources.ApplyResources(this.toolsMenuItem, "toolsMenuItem");
             this.toolsMenuItem.DropDownOpening += new System.EventHandler(this.ToolsMenuItem_DropDownOpening);
-            // 
+            //
             // menuItem13
-            // 
+            //
             resources.ApplyResources(this.menuItem13, "menuItem13");
             this.menuItem13.Name = "menuItem13";
-            // 
+            //
+            // exportMapT3DMenuItem
+            //
+            this.exportMapT3DMenuItem.Name = "exportMapT3DMenuItem";
+            resources.ApplyResources(this.exportMapT3DMenuItem, "exportMapT3DMenuItem");
+            this.exportMapT3DMenuItem.Click += new System.EventHandler(this.ExportMapT3DMenuItem_Click);
+            //
             // separator3
-            // 
+            //
             this.separator3.Name = "separator3";
             resources.ApplyResources(this.separator3, "separator3");
             // 
@@ -453,6 +461,7 @@ namespace UEExplorer.UI
         private System.Windows.Forms.ToolStripMenuItem saveFileMenuItem;
         private System.Windows.Forms.ToolStripSeparator separator2;
         private System.Windows.Forms.ToolStripMenuItem menuItem13;
+        private System.Windows.Forms.ToolStripMenuItem exportMapT3DMenuItem;
         private System.Windows.Forms.ToolStripSeparator separator3;
         private System.Windows.Forms.ToolStripMenuItem cacheExtractorMenuItem;
         private System.Windows.Forms.ToolStripSeparator separator4;

--- a/UE Explorer/UI/Main/ProgramForm.cs
+++ b/UE Explorer/UI/Main/ProgramForm.cs
@@ -165,6 +165,15 @@ namespace UEExplorer.UI
         {
             toggleFilesAssociationMenuItem.Checked = Program.AreFileTypesRegistered();
 
+            if (Tabs.SelectedComponent is UC_PackageExplorer explorer)
+            {
+                exportMapT3DMenuItem.Enabled = explorer.CanExportMapT3D;
+            }
+            else
+            {
+                exportMapT3DMenuItem.Enabled = false;
+            }
+
             if (menuItem13.Enabled)
             {
                 return;
@@ -330,6 +339,23 @@ namespace UEExplorer.UI
 
         private void CacheExtractorMenuItem_Click(object sender, EventArgs e) =>
             Tabs.InsertTab(typeof(UC_CacheExtractor), Resources.ProgramForm_Cache_Extractor);
+
+        private void ExportMapT3DMenuItem_Click(object sender, EventArgs e)
+        {
+            if (Tabs.SelectedComponent is UC_PackageExplorer explorer)
+            {
+                var package = explorer.Package;
+                var exportPath = package.ExportMapT3D();
+                var dialogResult = MessageBox.Show(
+                    string.Format(Resources.EXPORTED_MAP_T3D, package.PackageName, exportPath),
+                    Application.ProductName,
+                    MessageBoxButtons.YesNo);
+                if (dialogResult == DialogResult.Yes)
+                {
+                    Process.Start(exportPath);
+                }
+            }
+        }
 
         private void TabComponentsStrip_TabStripItemClosing(TabStripItemClosingEventArgs e) => e.Item.Dispose();
 

--- a/UE Explorer/UI/Main/ProgramForm.nl.resx
+++ b/UE Explorer/UI/Main/ProgramForm.nl.resx
@@ -190,6 +190,9 @@
   <data name="menuItem13.Text" xml:space="preserve">
     <value>&amp;Extensies</value>
   </data>
+  <data name="exportMapT3DMenuItem.Text" xml:space="preserve">
+    <value>Map exporteren (.t3d)</value>
+  </data>
   <data name="findToolMenuItem.Text" xml:space="preserve">
     <value>&amp;Zoeken</value>
   </data>

--- a/UE Explorer/UI/Main/ProgramForm.resx
+++ b/UE Explorer/UI/Main/ProgramForm.resx
@@ -408,6 +408,12 @@
   <data name="menuItem13.Text" xml:space="preserve">
     <value>&amp;Extensions</value>
   </data>
+  <data name="exportMapT3DMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>208, 22</value>
+  </data>
+  <data name="exportMapT3DMenuItem.Text" xml:space="preserve">
+    <value>Export Map (.t3d)</value>
+  </data>
   <data name="separator3.Size" type="System.Drawing.Size, System.Drawing">
     <value>205, 6</value>
   </data>
@@ -2220,6 +2226,12 @@
     <value>menuItem13</value>
   </data>
   <data name="&gt;&gt;menuItem13.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;exportMapT3DMenuItem.Name" xml:space="preserve">
+    <value>exportMapT3DMenuItem</value>
+  </data>
+  <data name="&gt;&gt;exportMapT3DMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;separator3.Name" xml:space="preserve">

--- a/UE Explorer/UI/Tabs/UC_PackageExplorer.Designer.cs
+++ b/UE Explorer/UI/Tabs/UC_PackageExplorer.Designer.cs
@@ -35,6 +35,7 @@
             this.checkBox1 = new System.Windows.Forms.CheckBox();
             this.exportDecompiledClassesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportScriptClassesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportMapT3DToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.Panel_Main = new System.Windows.Forms.Panel();
             this.panel1 = new System.Windows.Forms.Panel();
@@ -352,7 +353,8 @@
             exportingToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             exportingToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.exportDecompiledClassesToolStripMenuItem,
-            this.exportScriptClassesToolStripMenuItem});
+            this.exportScriptClassesToolStripMenuItem,
+            this.exportMapT3DToolStripMenuItem});
             resources.ApplyResources(exportingToolStripMenuItem, "exportingToolStripMenuItem");
             exportingToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(20)))), ((int)(((byte)(20)))), ((int)(((byte)(20)))));
             exportingToolStripMenuItem.Name = "exportingToolStripMenuItem";
@@ -364,10 +366,16 @@
             this.exportDecompiledClassesToolStripMenuItem.Name = "exportDecompiledClassesToolStripMenuItem";
             // 
             // exportScriptClassesToolStripMenuItem
-            // 
+            //
             resources.ApplyResources(this.exportScriptClassesToolStripMenuItem, "exportScriptClassesToolStripMenuItem");
             this.exportScriptClassesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(20)))), ((int)(((byte)(20)))), ((int)(((byte)(20)))));
             this.exportScriptClassesToolStripMenuItem.Name = "exportScriptClassesToolStripMenuItem";
+            //
+            // exportMapT3DToolStripMenuItem
+            //
+            resources.ApplyResources(this.exportMapT3DToolStripMenuItem, "exportMapT3DToolStripMenuItem");
+            this.exportMapT3DToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(20)))), ((int)(((byte)(20)))), ((int)(((byte)(20)))));
+            this.exportMapT3DToolStripMenuItem.Name = "exportMapT3DToolStripMenuItem";
             // 
             // splitContainer1
             // 
@@ -1272,8 +1280,9 @@
 		private System.Windows.Forms.Panel Panel_Main;
 		private System.Windows.Forms.ToolStrip ToolStrip_Main;
 		private System.Windows.Forms.ToolStripDropDownButton _Tools_StripDropDownButton;
-		public System.Windows.Forms.ToolStripMenuItem exportDecompiledClassesToolStripMenuItem;
+        public System.Windows.Forms.ToolStripMenuItem exportDecompiledClassesToolStripMenuItem;
         public System.Windows.Forms.ToolStripMenuItem exportScriptClassesToolStripMenuItem;
+        public System.Windows.Forms.ToolStripMenuItem exportMapT3DToolStripMenuItem;
 		internal System.Windows.Forms.TabPage TabPage_Objects;
         internal System.Windows.Forms.TabPage TabPage_Classes;
 		internal System.Windows.Forms.TabPage TabPage_Deps;

--- a/UE Explorer/UI/Tabs/UC_PackageExplorer.cs
+++ b/UE Explorer/UI/Tabs/UC_PackageExplorer.cs
@@ -494,6 +494,7 @@ namespace UEExplorer.UI.Tabs
             ProgressStatus.SetStatus( Resources.INITIALIZING_UI );
             exportDecompiledClassesToolStripMenuItem.Click += _OnExportClassesClick;
             exportScriptClassesToolStripMenuItem.Click += _OnExportScriptsClick;
+            exportMapT3DToolStripMenuItem.Click += _OnExportMapT3DClick;
             
             InitializeTabs();
 
@@ -554,6 +555,11 @@ namespace UEExplorer.UI.Tabs
             if (_UnrealPackage.Summary.CompressedChunks == null || _UnrealPackage.Summary.CompressedChunks.Count == 0)
             {
                 TabControl_Objects.Controls.Remove( TabPage_Chunks );
+            }
+
+            if( !_UnrealPackage.Objects.OfType<ULevel>().Any( l => l.ExportTable != null ) )
+            {
+                exportMapT3DToolStripMenuItem.Enabled = false;
             }
         }
 
@@ -863,14 +869,19 @@ namespace UEExplorer.UI.Tabs
         }
 
         private void _OnExportScriptsClick( object sender, EventArgs e )
-        {	
-            DoExportPackageClasses( true );	
+        {
+            DoExportPackageClasses( true );
+        }
+
+        private void _OnExportMapT3DClick( object sender, EventArgs e )
+        {
+            DoExportMapT3D();
         }
 
         private void DoExportPackageClasses( bool exportScripts = false )
         {
             var exportPath = _UnrealPackage.ExportPackageClasses( exportScripts );
-            var dialogResult = MessageBox.Show( 
+            var dialogResult = MessageBox.Show(
                 String.Format( 
                     Resources.EXPORTED_ALL_PACKAGE_CLASSES, 
                     _UnrealPackage.PackageName, 
@@ -878,6 +889,24 @@ namespace UEExplorer.UI.Tabs
                 ), 
                 Application.ProductName,
                 MessageBoxButtons.YesNo 
+            );
+            if( dialogResult == DialogResult.Yes )
+            {
+                Process.Start( exportPath );
+            }
+        }
+
+        private void DoExportMapT3D()
+        {
+            var exportPath = _UnrealPackage.ExportMapT3D();
+            var dialogResult = MessageBox.Show(
+                String.Format(
+                    Resources.EXPORTED_MAP_T3D,
+                    _UnrealPackage.PackageName,
+                    exportPath
+                ),
+                Application.ProductName,
+                MessageBoxButtons.YesNo
             );
             if( dialogResult == DialogResult.Yes )
             {

--- a/UE Explorer/UI/Tabs/UC_PackageExplorer.cs
+++ b/UE Explorer/UI/Tabs/UC_PackageExplorer.cs
@@ -33,6 +33,8 @@ namespace UEExplorer.UI.Tabs
         /// My Unreal file package!
         /// </summary>
         private UnrealPackage _UnrealPackage;
+        public UnrealPackage Package => _UnrealPackage;
+        public bool CanExportMapT3D => _UnrealPackage?.Objects.OfType<ULevel>().Any( l => l.ExportTable != null ) == true;
 
         private Keys _FindNextShortcutKeys;
         private Keys _ViewBufferShortcutKeys;

--- a/UE Explorer/UI/Tabs/UC_PackageExplorer.nl.resx
+++ b/UE Explorer/UI/Tabs/UC_PackageExplorer.nl.resx
@@ -240,6 +240,9 @@
   <data name="exportScriptClassesToolStripMenuItem.Text" xml:space="preserve">
     <value>Exporteer &amp;schriften</value>
   </data>
+  <data name="exportMapT3DToolStripMenuItem.Text" xml:space="preserve">
+    <value>Exporteer &amp;T3D</value>
+  </data>
   <data name="toolStripMenuItem1.Text" xml:space="preserve">
     <value>&amp;Zoeken</value>
   </data>

--- a/UE Explorer/UI/Tabs/UC_PackageExplorer.resx
+++ b/UE Explorer/UI/Tabs/UC_PackageExplorer.resx
@@ -720,6 +720,15 @@
   <data name="exportScriptClassesToolStripMenuItem.Text" xml:space="preserve">
     <value>Export &amp;Scripts</value>
   </data>
+  <data name="exportMapT3DToolStripMenuItem.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="exportMapT3DToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>149, 22</value>
+  </data>
+  <data name="exportMapT3DToolStripMenuItem.Text" xml:space="preserve">
+    <value>Export &amp;T3D</value>
+  </data>
   <data name="exportingToolStripMenuItem.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>


### PR DESCRIPTION
## Summary
- support dumping maps to `.t3d` via new helper
- add `-export=t3d` console option

## Testing
- `dotnet build 'UE Explorer/UEExplorer.csproj'` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b16499231c8328ae06144b7d443e8b